### PR TITLE
allow view proflie though chat interface, member list with dropdown

### DIFF
--- a/front_end/app/src/components/ChatBoxChannel.vue
+++ b/front_end/app/src/components/ChatBoxChannel.vue
@@ -10,7 +10,7 @@
                         <i class="bi bi-sliders2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" style="font-size: 2rem; color: #ffffff;"></i>
                         <ul class="dropdown-menu">
                             <li><a class="dropdown-item" data-bs-toggle="modal" data-bs-target="#membersList">View All Members</a></li>
-                            <li><a class="dropdown-item" href="#">Leavel Channel</a></li>
+                            <li><a class="dropdown-item" href="#" @click="leaveChannel()">Leavel Channel</a></li>
                         </ul>
                     </div>
                 </div>
@@ -48,7 +48,22 @@
                 </div>
                 <div class="modal-body">
                     <div v-for="member in allMembers" :key="member.intraId">
-                        {{ member.name }}
+                        <div class="dropdown">
+                            <button class="btn btn-secondary dropdown-toggle" type="button" id="user-dropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                                {{ member.name }}
+                            </button>
+                            <ul class="dropdown-menu" aria-labelledby="user-dropdown">
+                                <li><a class="dropdown-item" href="#">
+                                    <RouterLink class="nav-link" 
+                                    :to="{path: '/profile/other/' + member.intraId}">
+                                    View Profile</RouterLink>
+                                </a></li>
+                                <li><a class="dropdown-item" href="#" @click="banUser(member.intraId, activeChannel)">Ban</a></li>
+                                <li><a class="dropdown-item" href="#" @click="muteUser(member.intraId, activeChannel)">Mute</a></li>
+                                <li><a class="dropdown-item" href="#" @click="kickUser(member.intraId, activeChannel)">kick</a></li>
+                                <li><a class="dropdown-item" href="#">set as administrator</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
                 </div>
@@ -154,7 +169,6 @@ async function loadAllMembers(channelName: string): Promise<void> {
     try {
 		const response = await axiosInstance.get('chat/getMembersInChannel', { params: request });
         allMembers.value = response.data;
-        console.log(allMembers.value);
 	}
     catch (error: any) {
 		toast.add({
@@ -165,6 +179,25 @@ async function loadAllMembers(channelName: string): Promise<void> {
         });
 	}
 };
+
+// don't know if it's working, does not have enough accouts to test it fully
+async function kickUser(otherIntraId: number, channelName: string): Promise<void> {
+	socket.emit('kickUser', { otherIntraId: otherIntraId, channelName: channelName });
+}
+
+async function banUser(otherIntraId: number, channelName: string): Promise<void> {
+	socket.emit('banUser', { otherIntraId: otherIntraId, channelName: channelName });
+}
+
+async function muteUser(otherIntraId: number, channelName: string): Promise<void> {
+	socket.emit('muteUser', { otherIntraId: otherIntraId, channelName: channelName });
+}
+
+// not working for this moment, don't know why
+function leaveChannel(): void {
+	socket.emit('leaveChannel', activeChannel);
+}
+
 </script>
 
 <style scoped>

--- a/front_end/app/src/components/ChatBoxDm.vue
+++ b/front_end/app/src/components/ChatBoxDm.vue
@@ -12,7 +12,12 @@
                     <i class="bi bi-sliders2 dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" style="font-size: 2rem; color: #ffffff;"></i>
                     <ul class="dropdown-menu">
                         <li><a class="dropdown-item" href="#">Invite for Game</a></li>
-                        <li><a class="dropdown-item" href="#">View Profile</a></li>
+                        <li><a  class="dropdown-item" href="#">
+                            <RouterLink class="nav-link" 
+                                :to="{path: '/profile/other/' + otherUserIntraId}">
+                                View Profile</RouterLink>
+                            </a>
+                        </li>
                     </ul>
                 </div>
             </div>
@@ -86,6 +91,7 @@ const messageText = ref('');
 
 const dmAlias = ref('');
 const dmAvatar = ref('');
+const otherUserIntraId = ref();
 
 async function getDmInfo(): Promise<void> {
 	await axios
@@ -97,6 +103,7 @@ async function getDmInfo(): Promise<void> {
             const thisDm: DmChannel[] = channels.filter((channelId) => {
 				return (channelId.channel.channelName === props.channelName);
 			});
+            otherUserIntraId.value = thisDm[0].otherUser.intraId
             dmAlias.value = thisDm[0].otherUser.name;
             dmAvatar.value = 'http://localhost:3001/user/get_avatar?avatar=' + thisDm[0].otherUser.avatar
 		})

--- a/front_end/app/src/components/ChatChannelList.vue
+++ b/front_end/app/src/components/ChatChannelList.vue
@@ -36,7 +36,7 @@ onMounted(async () => {
 
 async function getMyChannels(): Promise<void> {
     await axios
-        .get("http://localhost:3001/chat/getAllChannels", {
+        .get("http://localhost:3001/chat/getMyChannels", {
             withCredentials: true,
         })
         .then(async (response) =>  {

--- a/front_end/app/src/views/ChatView.vue
+++ b/front_end/app/src/views/ChatView.vue
@@ -87,7 +87,7 @@ function catchEvent(event) {
 
 async function getMyChannels(): Promise<void> {
 	await axios
-		.get("http://localhost:3001/chat/getAllChannels", {
+		.get("http://localhost:3001/chat/getMyChannels", {
 			withCredentials: true,
 		})
 		.then(async (response) => {


### PR DESCRIPTION
- direct chat box dropdown has the view profile feature
- channel chat box dropdown can open the list of members
- each member has a dropdown menu of kick, ban, mute (these three haven't been tested), set as admin (not implemented), and view profile (working)
- channel chat box dropdown can leave the channel (not working, and I don't know why)