### PR TITLE
126 small be match history wrapup

### DIFF
--- a/back_end/app/prisma/schema.prisma
+++ b/back_end/app/prisma/schema.prisma
@@ -62,10 +62,12 @@ model User {
 
 model MatchHistory {
     id             Int @id @default(autoincrement())
-    intraId        Int
-    otherIntraId   Int
-    scoreUser      Int
-    scoreOtherUser Int
+    player1IntraId        Int
+    player2IntraId        Int
+    player1Score          Int
+    player2Score          Int
+    player1Avatar         String
+    player2Avatar         String
 }
 
 model AllOtherUsers {

--- a/back_end/app/prisma/schema.prisma
+++ b/back_end/app/prisma/schema.prisma
@@ -2,131 +2,133 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 enum ActivityStatus {
-    ONLINE
-    INGAME
-    OFFLINE
+	ONLINE
+	INGAME
+	OFFLINE
 }
 
 enum FriendStatus {
-    NOT_FRIENDS
-    REQUESTED
-    PENDING
-    FRIENDS
+	NOT_FRIENDS
+	REQUESTED
+	PENDING
+	FRIENDS
 }
 
 enum Role {
-    OWNER
-    ADMIN
-    MEMBER
+	OWNER
+	ADMIN
+	MEMBER
 }
 
 enum ChannelMode {
-    PRIVATE
-    PROTECTED
-    PUBLIC
+	PRIVATE
+	PROTECTED
+	PUBLIC
 }
 
 enum ChannelType {
-    NORMAL
-    DM
+	NORMAL
+	DM
 }
 
 datasource db {
-    provider = "postgresql"
-    url      = env("DATABASE_URL")
+	provider	= "postgresql"
+	url			= env("DATABASE_URL")
 }
 
 generator client {
-    provider = "prisma-client-js"
+	provider = "prisma-client-js"
 }
 
 model User {
-    id             Int             @id @default(autoincrement())
-    createdAt      DateTime        @default(now())
-    updatedAt      DateTime        @updatedAt
-    avatar         String?
-    twofaStatus    Boolean         @default(false)
-    twofaSecret    String          @default("")
-    name           String          @unique
-    wins           Int             @default(0)
-    losses         Int             @default(0)
-    elo            Int             @default(1500)
-    intraId        Int             @unique
-    intraName      String          @unique
-    activityStatus ActivityStatus  @default(ONLINE)
-    allOtherUsers  AllOtherUsers[]
-    achievements   Achievements?
-    memberships    Membership[]    @relation("UserMembership")
-    userMessage    UserMessage[]   @relation("UserMessage")
+	id				Int				@id @default(autoincrement())
+	createdAt		DateTime		@default(now())
+	updatedAt		DateTime		@updatedAt
+	avatar			String?
+	twofaStatus		Boolean			@default(false)
+	twofaSecret		String			@default("")
+	name			String			@unique
+	wins			Int				@default(0)
+	losses			Int				@default(0)
+	elo				Int				@default(1500)
+	intraId			Int				@unique
+	intraName		String			@unique
+	activityStatus	ActivityStatus  @default(ONLINE)
+	allOtherUsers	AllOtherUsers[]
+	achievements	Achievements?
+	memberships		Membership[]	@relation("UserMembership")
+	userMessage		UserMessage[]	@relation("UserMessage")
 }
 
 model MatchHistory {
-    id             Int @id @default(autoincrement())
-    player1IntraId        Int
-    player2IntraId        Int
-    player1Score          Int
-    player2Score          Int
-    player1Avatar         String
-    player2Avatar         String
+	id					Int @id @default(autoincrement())
+	winnerIntraId		Int
+	loserIntraId		Int
+	winnerScore			Int
+	loserScore			Int
+	winnerName			String
+	loserName			String
+	winnerAvatar		String
+	loserAvatar			String
 }
 
 model AllOtherUsers {
-    id            Int          @id @default(autoincrement())
-    intraId       Int
-    otherIntraId  Int
-    user          User         @relation(fields: [intraId], references: [intraId])
-    blockedStatus Boolean      @default(false)
-    friendStatus  FriendStatus @default(NOT_FRIENDS)
+	id				Int				@id @default(autoincrement())
+	intraId			Int
+	otherIntraId	Int
+	user			User			@relation(fields: [intraId], references: [intraId])
+	blockedStatus	Boolean			@default(false)
+	friendStatus	FriendStatus	@default(NOT_FRIENDS)
 
-    @@unique([intraId, otherIntraId])
+	@@unique([intraId, otherIntraId])
 }
 
 model Achievements {
-    id             Int     @id @default(autoincrement())
-    intraId        Int     @unique
-    wonGame        Boolean @default(false)
-    won3Game       Boolean @default(false)
-    won3GameRow    Boolean @default(false)
-    loseGame       Boolean @default(false)
-    lose3GameRow   Boolean @default(false)
-    playedGame     Boolean @default(false)
-    changedName    Boolean @default(false)
-    uploadedAvatar Boolean @default(false)
-    added2FA       Boolean @default(false)
-    rank1          Boolean @default(false)
-    user           User    @relation(fields: [intraId], references: [intraId])
+	id				Int		@id @default(autoincrement())
+	intraId			Int		@unique
+	wonGame			Boolean @default(false)
+	won3Game		Boolean @default(false)
+	won3GameRow		Boolean @default(false)
+	loseGame		Boolean @default(false)
+	lose3GameRow	Boolean @default(false)
+	playedGame		Boolean @default(false)
+	changedName		Boolean @default(false)
+	uploadedAvatar	Boolean @default(false)
+	added2FA		Boolean @default(false)
+	rank1			Boolean @default(false)
+	user			User	@relation(fields: [intraId], references: [intraId])
 }
 
 model Channel {
-    id           Int           @id @default(autoincrement())
-    channelMode  ChannelMode
-    channelName  String        @unique
-    channelType  ChannelType   @default(NORMAL)
-    password     String        @default("")
-    userMessages UserMessage[]
-    memberships  Membership[]  @relation("ChannelMembership")
+	id				Int				@id @default(autoincrement())
+	channelMode		ChannelMode
+	channelName		String			@unique
+	channelType		ChannelType		@default(NORMAL)
+	password		String			@default("")
+	userMessages	UserMessage[]
+	memberships		Membership[]	@relation("ChannelMembership")
 }
 
 model Membership {
-    id          Int       @id @default(autoincrement())
-    role        Role      @default(MEMBER)
-    banStatus   Boolean   @default(false)
-    banTimer    DateTime?
-    muteStatus  Boolean   @default(false)
-    muteTimer   DateTime?
-    user        User      @relation("UserMembership", fields: [intraId], references: [intraId])
-    intraId     Int
-    channel     Channel   @relation("ChannelMembership", fields: [channelName], references: [channelName], onDelete: Cascade)
-    channelName String
+	id			Int			@id @default(autoincrement())
+	role		Role		@default(MEMBER)
+	banStatus	Boolean		@default(false)
+	banTimer	DateTime?
+	muteStatus	Boolean		@default(false)
+	muteTimer	DateTime?
+	user		User		@relation("UserMembership", fields: [intraId], references: [intraId])
+	intraId		Int
+	channel		Channel		@relation("ChannelMembership", fields: [channelName], references: [channelName], onDelete: Cascade)
+	channelName	String
 
-    @@unique([intraId, channelName])
+	@@unique([intraId, channelName])
 }
 
 model UserMessage {
-    id          Int     @id @default(autoincrement())
-    text        String
-    channel     Channel @relation(fields: [channelName], references: [channelName], onDelete: Cascade)
-    channelName String
-    user        User    @relation("UserMessage", fields: [intraId], references: [intraId])
-    intraId     Int
+	id			Int		@id @default(autoincrement())
+	text		String
+	channel		Channel	@relation(fields: [channelName], references: [channelName], onDelete: Cascade)
+	channelName	String
+	user		User	@relation("UserMessage", fields: [intraId], references: [intraId])
+	intraId		Int
 }

--- a/back_end/app/src/game/game.module.ts
+++ b/back_end/app/src/game/game.module.ts
@@ -3,9 +3,10 @@ import { GameService } from './game.service';
 import { GameGateway } from './game.gateway';
 import { UserModule } from 'src/user/user.module';
 import { GameSharedService } from './game.shared.service';
+import { AuthModule } from 'src/auth/auth.module';
 
 @Module({
-	imports: [UserModule],
+	imports: [UserModule, AuthModule],
 	providers: [GameGateway, GameService, GameSharedService],
 	exports: [GameSharedService],
 })

--- a/back_end/app/src/game/game.service.ts
+++ b/back_end/app/src/game/game.service.ts
@@ -135,12 +135,9 @@ export class GameService {
 		return (gameStatus);
 	}
 
-	// endGame(gameStatus: Game): boolean {
-	// 	if (gameStatus.player1Score >= 3 || gameStatus.player2Score >= 3) {
-	// 		return true;
-	// 	}
-	// 	return false;
-	// }
+	endGame(gameStatus: Game): void {
+		
+	}
 
 	async update_win_loss_elo(winner: User, loser: User): Promise<void> {
 		const { newWinnerElo, newLoserElo }: { newWinnerElo: number, newLoserElo: number } = this.calculate_new_elo(winner.elo, loser.elo);

--- a/back_end/app/src/game/game.service.ts
+++ b/back_end/app/src/game/game.service.ts
@@ -146,13 +146,13 @@ export class GameService {
 	async endGame(gameStatus: Game, roomName: string): Promise<void> {
 		try {
 			let winner: boolean;
-			
+
 			if (this.shareService.playerData[roomName].player1Score === 3) {
 				winner = true;
 			} else {
 				winner = false;
 			}
-			
+
 			const player1: User = await this.authService.findUserById(this.shareService.playerData[roomName].player1);
 			const player2: User = await this.authService.findUserById(this.shareService.playerData[roomName].player2);
 
@@ -160,30 +160,31 @@ export class GameService {
 				await this.prisma.matchHistory.create({
 					data: {
 						winnerIntraId: player1.intraId,
-						loserIntraId: player2.intraId,
 						winnerScore: gameStatus.player1Score,
-						loserScore: gameStatus.player2Score,
 						winnerName: player1.name,
-						loserName: player2.name,
 						winnerAvatar: player1.avatar,
+						loserIntraId: player2.intraId,
+						loserScore: gameStatus.player2Score,
+						loserName: player2.name,
 						loserAvatar: player2.avatar,
 					}
 				});
+				this.update_win_loss_elo(player1, player2);
 			} else {
 				await this.prisma.matchHistory.create({
 					data: {
 						winnerIntraId: player2.intraId,
-						loserIntraId: player1.intraId,
 						winnerScore: gameStatus.player2Score,
-						loserScore: gameStatus.player1Score,
 						winnerName: player2.name,
-						loserName: player1.name,
 						winnerAvatar: player2.avatar,
+						loserIntraId: player1.intraId,
+						loserScore: gameStatus.player1Score,
+						loserName: player1.name,
 						loserAvatar: player1.avatar,
 					}
 				});
+				this.update_win_loss_elo(player2, player1);
 			}
-			this.update_win_loss_elo(player1, player2);
 		} catch (error) {
 			throw new InternalServerErrorException(error.message);
 		}
@@ -227,14 +228,14 @@ export class GameService {
 					elo: newWinnerElo,
 				},
 			});
-        } catch(error: any) {
-            if (error instanceof Prisma.PrismaClientKnownRequestError) {
-                if (error.code === 'P2001') {
-                    throw new NotFoundException('Unable to update achievement, user not found');
-                }
-            }
-            throw new InternalServerErrorException(error.message || "Prisma failed to update user.wins");
-        }
+		} catch(error: any) {
+			if (error instanceof Prisma.PrismaClientKnownRequestError) {
+				if (error.code === 'P2001') {
+					throw new NotFoundException('Unable to update achievement, user not found');
+				}
+			}
+			throw new InternalServerErrorException(error.message || "Prisma failed to update user.wins");
+		}
 	}
 
 	private async update_loser(loserIntraId: number, newLoserElo: number): Promise<void> {
@@ -251,12 +252,12 @@ export class GameService {
 				},
 			});
 		} catch(error: any) {
-            if (error instanceof Prisma.PrismaClientKnownRequestError) {
-                if (error.code === 'P2001') {
-                    throw new NotFoundException('Unable to update achievement, user not found');
-                }
-            }
-            throw new InternalServerErrorException(error.message || "Prisma failed to update user.losses");
-        }
+			if (error instanceof Prisma.PrismaClientKnownRequestError) {
+				if (error.code === 'P2001') {
+					throw new NotFoundException('Unable to update achievement, user not found');
+				}
+			}
+			throw new InternalServerErrorException(error.message || "Prisma failed to update user.losses");
+		}
 	}
 }

--- a/back_end/app/src/user/user.controller.ts
+++ b/back_end/app/src/user/user.controller.ts
@@ -69,8 +69,12 @@ export class UserController {
 	@Get('get_match_history_by_intraid') 
 	async getMatchHistoryByIntraId(@Query() query): Promise<MatchHistory[]> {
 		const otherIntraId: number = parseInt(query.intraId);
-		console.log(otherIntraId);
 		return (await this.userService.getMatchHistory(otherIntraId));
+	}
+
+	@Get('get_leaderboard')
+	async getLeaderboard(): Promise<User[]> {
+		return (await this.userService.getLeaderboard());
 	}
 
 	@Get(':id')

--- a/back_end/app/src/user/user.controller.ts
+++ b/back_end/app/src/user/user.controller.ts
@@ -1,5 +1,5 @@
 import { Body, Controller, Get, Post, Req, UseGuards, Param, UseInterceptors, BadRequestException, UploadedFile, Query, StreamableFile, Put } from '@nestjs/common';
-import { Achievements, User } from '@prisma/client';
+import { Achievements, MatchHistory, User } from '@prisma/client';
 import { JwtAuthGuard } from 'src/auth/guards';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { OtherUserIntraDto } from './dto/other-user-intra.dto';
@@ -59,6 +59,11 @@ export class UserController {
 	@Get('get_avatar')
 	getAvatar(@Query('avatar') avatar: string): StreamableFile {
 		return (this.userService.getAvatar(avatar));
+	}
+
+	@Get('get_match_history')
+	async getMatchHistory(@GetUser() user: User): Promise<MatchHistory[]> {
+		return (await this.userService.getMatchHistory(user));
 	}
 
 	@Get(':id')

--- a/back_end/app/src/user/user.controller.ts
+++ b/back_end/app/src/user/user.controller.ts
@@ -63,7 +63,14 @@ export class UserController {
 
 	@Get('get_match_history')
 	async getMatchHistory(@GetUser() user: User): Promise<MatchHistory[]> {
-		return (await this.userService.getMatchHistory(user));
+		return (await this.userService.getMatchHistory(user.intraId));
+	}
+
+	@Get('get_match_history_by_intraid') 
+	async getMatchHistoryByIntraId(@Query() query): Promise<MatchHistory[]> {
+		const otherIntraId: number = parseInt(query.intraId);
+		console.log(otherIntraId);
+		return (await this.userService.getMatchHistory(otherIntraId));
 	}
 
 	@Get(':id')

--- a/back_end/app/src/user/user.service.ts
+++ b/back_end/app/src/user/user.service.ts
@@ -320,6 +320,19 @@ export class UserService {
 		}
 	}
 
+	async getLeaderboard(): Promise<User[]> {
+		try {
+			const userArray: User[] = await this.prisma.user.findMany({
+				orderBy: {
+					elo: 'desc',
+				},
+			});
+			return (userArray);
+		} catch (error) {
+			throw new InternalServerErrorException(error.message);
+		}
+	}
+
 	async updateUsername(user: User, newUsername: string) {
 		try {
 			const updatedUser: (User & { achievements: Achievements }) = await this.prisma.user.update({

--- a/back_end/app/src/user/user.service.ts
+++ b/back_end/app/src/user/user.service.ts
@@ -300,16 +300,16 @@ export class UserService {
 		return new StreamableFile(file);
 	}
 
-	async getMatchHistory(user: User): Promise<MatchHistory[]> {
+	async getMatchHistory(intraId: number): Promise<MatchHistory[]> {
 		try {
 			const matchHistory: MatchHistory[] = await this.prisma.matchHistory.findMany({
 				where: {
 					OR: [
 						{
-							winnerIntraId: user.intraId,
+							winnerIntraId: intraId,
 						},
 						{
-							loserIntraId: user.intraId,
+							loserIntraId: intraId,
 						},
 					],
 				},

--- a/front_end/app/src/views/GameView.vue
+++ b/front_end/app/src/views/GameView.vue
@@ -184,7 +184,7 @@ export default {
 	},
 
 	beforeRouteLeave() {
-		this.socket.emit('endGame', this.roomName, () => {
+		this.socket.emit('endGame', this.roomName, players.player1.intraId, players.player2.intraId, () => {
 			this.socket.disconnect();
 		});
 		console.log(this.playerDisconnect, 'beforeRouterLeave');


### PR DESCRIPTION
CREATED NEW ROUTES:

`http://localhost:3001/user/get_match_history`
- Returns the match history of the currently logged in player, for its own profile
`http://localhost:3001/user/get_match_history_by_intraid`
- Requires intraid of the other user in a query, so http://localhost:3001/user/get_match_history_by_intraid&intraId=63991 returns the match history of the intranet user 63991. Can be used in viewing other users their profiles
`http://localhost:3001/user/get_leaderboard`
- Returns the leaderboard, sorted by most points first and fewest points last.

Added function in game.service.ts:
`async endGame(gameStatus: Game, roomName: string): Promise<void>`
- Takes in the gameStatus and the roomName once a game has finished and creates a database element based on winner. Also calls the update_win_loss_elo afterwards to reflect the new elo scores of the winner and the loser. 

Added function in user.service.ts:
`async updateUsernameInMatchHistory(user: User, newUsername: string): Promise<void>` 
- Called whenever a user changes their username, updates all entries in the match history known of them.